### PR TITLE
feat: I18n support for extension names and descriptions

### DIFF
--- a/chrome-extension/_locales/en/messages.json
+++ b/chrome-extension/_locales/en/messages.json
@@ -1,4 +1,10 @@
 {
+	"extension_name": {
+		"message": "Open local folder by explorer"
+	},
+	"extension_description": {
+		"message": "Open local folder in explorer from Chrome"
+	},
 	"_locale_code": {
         "message": "en",
         "description": "To specify the language used for multilingual support in the html file"

--- a/chrome-extension/_locales/ja/messages.json
+++ b/chrome-extension/_locales/ja/messages.json
@@ -1,4 +1,10 @@
 {
+	"extension_name": {
+		"message": "Open local folder by explorer"
+	},
+	"extension_description": {
+		"message": "Chromeからローカルフォルダーをエクスプローラーで開く"
+	},
 	"_locale_code": {
 		"message": "ja",
         "description": "htmlファイル中の多言語対応のための使用言語の特定用"

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,6 +1,6 @@
 {
-	"name": "Open local folder by explorer",
-	"description": "Chromeからローカルフォルダーをエクスプローラーで開く",
+	"name": "__MSG_extension_name__",
+	"description": "__MSG_extension_description__",
 	"version": "0.2.0",
 	"manifest_version": 2,
 	"default_locale": "en",


### PR DESCRIPTION
## Related Issue
- https://github.com/tksugimoto/chrome-extension_open-local-folder-by-explorer/issues/1 `日本語がわからないと使えない (Unable to use if you do not understand Japanese) · Issue #1 · tksugimoto/chrome-extension_open-local-folder-by-explorer`

## Reference page
- [chrome.i18n - Google Chrome](https://developer.chrome.com/extensions/i18n "https://developer.chrome.com/extensions/i18n")